### PR TITLE
feat: added InsertContext and UpdateContext

### DIFF
--- a/db.go
+++ b/db.go
@@ -92,8 +92,8 @@ func (d *db) Insert(structPtr interface{}) (sql.Result, error) {
 	return d.s.Insert(structPtr)
 }
 
-func (d *db) InsertWithContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
-	return d.s.InsertWithContext(ctx, structPtr)
+func (d *db) InsertContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
+	return d.s.InsertContext(ctx, structPtr)
 }
 
 func (d *db) QueryForInsert(structPtr interface{}) (*SaveQuery, error) {
@@ -104,8 +104,8 @@ func (d *db) Update(table string, set map[string]interface{}, where Clause) (sql
 	return d.s.Update(table, set, where)
 }
 
-func (d *db) UpdateWithContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
-	return d.s.UpdateWithContext(ctx, table, set, where)
+func (d *db) UpdateContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
+	return d.s.UpdateContext(ctx, table, set, where)
 }
 
 func (d *db) QueryForUpdate(table string, set map[string]interface{}, where Clause) (*SaveQuery, error) {

--- a/db.go
+++ b/db.go
@@ -34,7 +34,9 @@ type db struct {
 }
 
 type OpenOptions struct {
-	Url string
+	// @default "mysql"
+	DriverName string
+	Url        string
 	// @default 5
 	MaxRetryCount int
 	// @default 5s
@@ -42,6 +44,10 @@ type OpenOptions struct {
 }
 
 func Open(opts *OpenOptions) (DB, error) {
+	driverName := "mysql"
+	if opts.DriverName != "" {
+		driverName = opts.DriverName
+	}
 	maxRetryCount := 5
 	retryInterval := 5 * time.Second
 	if opts.MaxRetryCount > 0 {
@@ -54,7 +60,7 @@ func Open(opts *OpenOptions) (DB, error) {
 	var err error
 	retryCnt := 0
 	for retryCnt < maxRetryCount {
-		d, err = sql.Open("mysql", opts.Url)
+		d, err = sql.Open(driverName, opts.Url)
 		if err != nil {
 			goto retry
 		} else if err = d.Ping(); err != nil {
@@ -86,12 +92,20 @@ func (d *db) Insert(structPtr interface{}) (sql.Result, error) {
 	return d.s.Insert(structPtr)
 }
 
+func (d *db) InsertContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
+	return d.s.InsertContext(ctx, structPtr)
+}
+
 func (d *db) QueryForInsert(structPtr interface{}) (*SaveQuery, error) {
 	return d.s.QueryForInsert(structPtr)
 }
 
 func (d *db) Update(table string, set map[string]interface{}, where Clause) (sql.Result, error) {
 	return d.s.Update(table, set, where)
+}
+
+func (d *db) UpdateContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
+	return d.s.UpdateContext(ctx, table, set, where)
 }
 
 func (d *db) QueryForUpdate(table string, set map[string]interface{}, where Clause) (*SaveQuery, error) {

--- a/db.go
+++ b/db.go
@@ -92,8 +92,8 @@ func (d *db) Insert(structPtr interface{}) (sql.Result, error) {
 	return d.s.Insert(structPtr)
 }
 
-func (d *db) InsertContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
-	return d.s.InsertContext(ctx, structPtr)
+func (d *db) InsertWithContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
+	return d.s.InsertWithContext(ctx, structPtr)
 }
 
 func (d *db) QueryForInsert(structPtr interface{}) (*SaveQuery, error) {
@@ -104,8 +104,8 @@ func (d *db) Update(table string, set map[string]interface{}, where Clause) (sql
 	return d.s.Update(table, set, where)
 }
 
-func (d *db) UpdateContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
-	return d.s.UpdateContext(ctx, table, set, where)
+func (d *db) UpdateWithContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
+	return d.s.UpdateWithContext(ctx, table, set, where)
 }
 
 func (d *db) QueryForUpdate(table string, set map[string]interface{}, where Clause) (*SaveQuery, error) {

--- a/saver.go
+++ b/saver.go
@@ -18,10 +18,10 @@ type SaveQuery struct {
 
 type Saver interface {
 	Insert(structPtr interface{}) (sql.Result, error)
-	InsertWithContext(ctx context.Context, structPtr interface{}) (sql.Result, error)
+	InsertContext(ctx context.Context, structPtr interface{}) (sql.Result, error)
 	QueryForInsert(structPtr interface{}) (*SaveQuery, error)
 	Update(table string, set map[string]interface{}, where Clause) (sql.Result, error)
-	UpdateWithContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error)
+	UpdateContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error)
 	QueryForUpdate(table string, set map[string]interface{}, where Clause) (*SaveQuery, error)
 }
 
@@ -41,10 +41,10 @@ func NewSaver(ex Executor) *saver {
 }
 
 func (s *saver) Insert(modelPtr interface{}) (sql.Result, error) {
-	return s.InsertWithContext(context.Background(), modelPtr)
+	return s.InsertContext(context.Background(), modelPtr)
 }
 
-func (s *saver) InsertWithContext(ctx context.Context, modelPtr interface{}) (sql.Result, error) {
+func (s *saver) InsertContext(ctx context.Context, modelPtr interface{}) (sql.Result, error) {
 	q, err := s.QueryForInsert(modelPtr)
 	if err != nil {
 		return nil, err
@@ -71,10 +71,10 @@ func (s *saver) Update(
 	set map[string]interface{},
 	where Clause,
 ) (sql.Result, error) {
-	return s.UpdateWithContext(context.Background(), table, set, where)
+	return s.UpdateContext(context.Background(), table, set, where)
 }
 
-func (s *saver) UpdateWithContext(
+func (s *saver) UpdateContext(
 	ctx context.Context,
 	table string,
 	set map[string]interface{},

--- a/saver.go
+++ b/saver.go
@@ -18,10 +18,10 @@ type SaveQuery struct {
 
 type Saver interface {
 	Insert(structPtr interface{}) (sql.Result, error)
-	InsertContext(ctx context.Context, structPtr interface{}) (sql.Result, error)
+	InsertWithContext(ctx context.Context, structPtr interface{}) (sql.Result, error)
 	QueryForInsert(structPtr interface{}) (*SaveQuery, error)
 	Update(table string, set map[string]interface{}, where Clause) (sql.Result, error)
-	UpdateContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error)
+	UpdateWithContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error)
 	QueryForUpdate(table string, set map[string]interface{}, where Clause) (*SaveQuery, error)
 }
 
@@ -41,10 +41,10 @@ func NewSaver(ex Executor) *saver {
 }
 
 func (s *saver) Insert(modelPtr interface{}) (sql.Result, error) {
-	return s.InsertContext(context.Background(), modelPtr)
+	return s.InsertWithContext(context.Background(), modelPtr)
 }
 
-func (s *saver) InsertContext(ctx context.Context, modelPtr interface{}) (sql.Result, error) {
+func (s *saver) InsertWithContext(ctx context.Context, modelPtr interface{}) (sql.Result, error) {
 	q, err := s.QueryForInsert(modelPtr)
 	if err != nil {
 		return nil, err
@@ -71,10 +71,10 @@ func (s *saver) Update(
 	set map[string]interface{},
 	where Clause,
 ) (sql.Result, error) {
-	return s.UpdateContext(context.Background(), table, set, where)
+	return s.UpdateWithContext(context.Background(), table, set, where)
 }
 
-func (s *saver) UpdateContext(
+func (s *saver) UpdateWithContext(
 	ctx context.Context,
 	table string,
 	set map[string]interface{},

--- a/saver_test.go
+++ b/saver_test.go
@@ -112,7 +112,7 @@ func TestSaver_Insert(t *testing.T) {
 	})
 }
 
-func TestSaver_InsertContext(t *testing.T) {
+func TestSaver_InsertWithContext(t *testing.T) {
 	d := testDb()
 	m := NewMapper()
 	s := NewSaver(d.DB())
@@ -121,7 +121,7 @@ func TestSaver_InsertContext(t *testing.T) {
 			FirstName: null.StringFrom("first"),
 			LastName:  null.StringFrom("last"),
 		}
-		result, err := s.InsertContext(context.Background(), user)
+		result, err := s.InsertWithContext(context.Background(), user)
 		assert.Nil(t, err)
 		assert.False(t, user.Id == 0)
 		defer func() {
@@ -176,7 +176,7 @@ func TestSaver_Update(t *testing.T) {
 	})
 }
 
-func TestSaver_UpdateContext(t *testing.T) {
+func TestSaver_UpdateWithContext(t *testing.T) {
 	d := testDb()
 	m := NewMapper()
 	s := NewSaver(d.DB())
@@ -190,7 +190,7 @@ func TestSaver_UpdateContext(t *testing.T) {
 		defer func() {
 			d.DB().Exec(`DELETE FROM users WHERE id = ?`, lid)
 		}()
-		result, err = s.UpdateContext(context.Background(), "users", map[string]interface{}{
+		result, err = s.UpdateWithContext(context.Background(), "users", map[string]interface{}{
 			"first_name": "go",
 			"last_name":  "lang",
 		}, Where(`id = ?`, lid))

--- a/saver_test.go
+++ b/saver_test.go
@@ -112,7 +112,7 @@ func TestSaver_Insert(t *testing.T) {
 	})
 }
 
-func TestSaver_InsertWithContext(t *testing.T) {
+func TestSaver_InsertContext(t *testing.T) {
 	d := testDb()
 	m := NewMapper()
 	s := NewSaver(d.DB())
@@ -121,7 +121,7 @@ func TestSaver_InsertWithContext(t *testing.T) {
 			FirstName: null.StringFrom("first"),
 			LastName:  null.StringFrom("last"),
 		}
-		result, err := s.InsertWithContext(context.Background(), user)
+		result, err := s.InsertContext(context.Background(), user)
 		assert.Nil(t, err)
 		assert.False(t, user.Id == 0)
 		defer func() {
@@ -176,7 +176,7 @@ func TestSaver_Update(t *testing.T) {
 	})
 }
 
-func TestSaver_UpdateWithContext(t *testing.T) {
+func TestSaver_UpdateContext(t *testing.T) {
 	d := testDb()
 	m := NewMapper()
 	s := NewSaver(d.DB())
@@ -190,7 +190,7 @@ func TestSaver_UpdateWithContext(t *testing.T) {
 		defer func() {
 			d.DB().Exec(`DELETE FROM users WHERE id = ?`, lid)
 		}()
-		result, err = s.UpdateWithContext(context.Background(), "users", map[string]interface{}{
+		result, err = s.UpdateContext(context.Background(), "users", map[string]interface{}{
 			"first_name": "go",
 			"last_name":  "lang",
 		}, Where(`id = ?`, lid))

--- a/saver_test.go
+++ b/saver_test.go
@@ -1,6 +1,7 @@
 package exql
 
 import (
+	"context"
 	"fmt"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/loilo-inc/exql/model"
@@ -111,6 +112,38 @@ func TestSaver_Insert(t *testing.T) {
 	})
 }
 
+func TestSaver_InsertContext(t *testing.T) {
+	d := testDb()
+	m := NewMapper()
+	s := NewSaver(d.DB())
+	t.Run("basic", func(t *testing.T) {
+		user := &model.Users{
+			FirstName: null.StringFrom("first"),
+			LastName:  null.StringFrom("last"),
+		}
+		result, err := s.InsertContext(context.Background(), user)
+		assert.Nil(t, err)
+		assert.False(t, user.Id == 0)
+		defer func() {
+			d.DB().Exec(`DELETE FROM users WHERE id = ?`, user.Id)
+		}()
+		r, err := result.RowsAffected()
+		assert.Nil(t, err)
+		assert.Equal(t, int64(1), r)
+		lid, err := result.LastInsertId()
+		assert.Nil(t, err)
+		assert.Equal(t, user.Id, lid)
+		rows, err := d.DB().Query(`SELECT * FROM users WHERE id = ?`, lid)
+		assert.Nil(t, err)
+		var actual model.Users
+		err = m.Map(rows, &actual)
+		assert.Nil(t, err)
+		assert.Equal(t, lid, actual.Id)
+		assert.Equal(t, user.FirstName.String, actual.FirstName.String)
+		assert.Equal(t, user.LastName.String, actual.LastName.String)
+	})
+}
+
 func TestSaver_Update(t *testing.T) {
 	d := testDb()
 	m := NewMapper()
@@ -126,6 +159,38 @@ func TestSaver_Update(t *testing.T) {
 			d.DB().Exec(`DELETE FROM users WHERE id = ?`, lid)
 		}()
 		result, err = s.Update("users", map[string]interface{}{
+			"first_name": "go",
+			"last_name":  "lang",
+		}, Where(`id = ?`, lid))
+		assert.Nil(t, err)
+		ra, err := result.RowsAffected()
+		assert.Nil(t, err)
+		assert.Equal(t, int64(1), ra)
+		var actual model.Users
+		rows, err := d.DB().Query(`SELECT * FROM users WHERE id = ?`, lid)
+		assert.Nil(t, err)
+		err = m.Map(rows, &actual)
+		assert.Nil(t, err)
+		assert.Equal(t, "go", actual.FirstName.String)
+		assert.Equal(t, "lang", actual.LastName.String)
+	})
+}
+
+func TestSaver_UpdateContext(t *testing.T) {
+	d := testDb()
+	m := NewMapper()
+	s := NewSaver(d.DB())
+	t.Run("basic", func(t *testing.T) {
+		result, err := d.DB().Exec(
+			"INSERT INTO `users` (`first_name`, `last_name`) VALUES (?, ?)",
+			"first", "last")
+		assert.Nil(t, err)
+		lid, err := result.LastInsertId()
+		assert.Nil(t, err)
+		defer func() {
+			d.DB().Exec(`DELETE FROM users WHERE id = ?`, lid)
+		}()
+		result, err = s.UpdateContext(context.Background(), "users", map[string]interface{}{
 			"first_name": "go",
 			"last_name":  "lang",
 		}, Where(`id = ?`, lid))

--- a/tx.go
+++ b/tx.go
@@ -22,8 +22,8 @@ func (t *tx) Insert(structPtr interface{}) (sql.Result, error) {
 	return t.s.Insert(structPtr)
 }
 
-func (t *tx) InsertWithContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
-	return t.s.InsertWithContext(ctx, structPtr)
+func (t *tx) InsertContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
+	return t.s.InsertContext(ctx, structPtr)
 }
 
 func (t *tx) QueryForInsert(structPtr interface{}) (*SaveQuery, error) {
@@ -34,8 +34,8 @@ func (t *tx) Update(table string, set map[string]interface{}, where Clause) (sql
 	return t.s.Update(table, set, where)
 }
 
-func (t *tx) UpdateWithContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
-	return t.s.UpdateWithContext(ctx, table, set, where)
+func (t *tx) UpdateContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
+	return t.s.UpdateContext(ctx, table, set, where)
 }
 
 func (t *tx) QueryForUpdate(table string, set map[string]interface{}, where Clause) (*SaveQuery, error) {

--- a/tx.go
+++ b/tx.go
@@ -22,12 +22,20 @@ func (t *tx) Insert(structPtr interface{}) (sql.Result, error) {
 	return t.s.Insert(structPtr)
 }
 
+func (t *tx) InsertContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
+	return t.s.InsertContext(ctx, structPtr)
+}
+
 func (t *tx) QueryForInsert(structPtr interface{}) (*SaveQuery, error) {
 	return t.s.QueryForInsert(structPtr)
 }
 
 func (t *tx) Update(table string, set map[string]interface{}, where Clause) (sql.Result, error) {
 	return t.s.Update(table, set, where)
+}
+
+func (t *tx) UpdateContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
+	return t.s.UpdateContext(ctx, table, set, where)
 }
 
 func (t *tx) QueryForUpdate(table string, set map[string]interface{}, where Clause) (*SaveQuery, error) {

--- a/tx.go
+++ b/tx.go
@@ -22,8 +22,8 @@ func (t *tx) Insert(structPtr interface{}) (sql.Result, error) {
 	return t.s.Insert(structPtr)
 }
 
-func (t *tx) InsertContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
-	return t.s.InsertContext(ctx, structPtr)
+func (t *tx) InsertWithContext(ctx context.Context, structPtr interface{}) (sql.Result, error) {
+	return t.s.InsertWithContext(ctx, structPtr)
 }
 
 func (t *tx) QueryForInsert(structPtr interface{}) (*SaveQuery, error) {
@@ -34,8 +34,8 @@ func (t *tx) Update(table string, set map[string]interface{}, where Clause) (sql
 	return t.s.Update(table, set, where)
 }
 
-func (t *tx) UpdateContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
-	return t.s.UpdateContext(ctx, table, set, where)
+func (t *tx) UpdateWithContext(ctx context.Context, table string, set map[string]interface{}, where Clause) (sql.Result, error) {
+	return t.s.UpdateWithContext(ctx, table, set, where)
 }
 
 func (t *tx) QueryForUpdate(table string, set map[string]interface{}, where Clause) (*SaveQuery, error) {


### PR DESCRIPTION
New RelicでDatabaseアクセスを計測できるようにするために、専用の関数：InsertContext、UpdateContextを追加しました
Insert、Updateとの違いは、contextを指定できるかどうかだけになります。

また、併せて外部からドライバー名を指定できるようにしました
確認お願いします 🙏

ref: https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrmysql