### PR TITLE
Add support microseconds precision for time, datetime, timestamp

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -165,7 +165,7 @@ func (p *parser) ParseType(t string, nullable bool) (string, error) {
 	charPat := regexp.MustCompile("^(var)?char\\(\\d+?\\)$")
 	textPat := regexp.MustCompile("^(tiny|medium|long)?text$")
 	blobPat := regexp.MustCompile("^(tiny|medium|long)?blob$")
-	datePat := regexp.MustCompile("^(date|datetime|timestamp)$")
+	datePat := regexp.MustCompile("^(date|datetime|datetime\\(\\d+\\)|timestamp)$")
 	timePat := regexp.MustCompile("^time$")
 	if intPat.MatchString(t) {
 		m := intPat.FindStringSubmatch(t)

--- a/parser.go
+++ b/parser.go
@@ -165,7 +165,7 @@ func (p *parser) ParseType(t string, nullable bool) (string, error) {
 	charPat := regexp.MustCompile("^(var)?char\\(\\d+?\\)$")
 	textPat := regexp.MustCompile("^(tiny|medium|long)?text$")
 	blobPat := regexp.MustCompile("^(tiny|medium|long)?blob$")
-	datePat := regexp.MustCompile("^(date|datetime|datetime\\(\\d+\\)|timestamp)$")
+	datePat := regexp.MustCompile("^(date|datetime|datetime\\(\\d\\)|timestamp)$")
 	timePat := regexp.MustCompile("^time$")
 	if intPat.MatchString(t) {
 		m := intPat.FindStringSubmatch(t)

--- a/parser.go
+++ b/parser.go
@@ -165,8 +165,8 @@ func (p *parser) ParseType(t string, nullable bool) (string, error) {
 	charPat := regexp.MustCompile("^(var)?char\\(\\d+?\\)$")
 	textPat := regexp.MustCompile("^(tiny|medium|long)?text$")
 	blobPat := regexp.MustCompile("^(tiny|medium|long)?blob$")
-	datePat := regexp.MustCompile("^(date|datetime|datetime\\(\\d\\)|timestamp)$")
-	timePat := regexp.MustCompile("^time$")
+	datePat := regexp.MustCompile("^(date|datetime|datetime\\(\\d\\)|timestamp|timestamp\\(\\d\\))$")
+	timePat := regexp.MustCompile("^(time|time\\(\\d\\))$")
 	if intPat.MatchString(t) {
 		m := intPat.FindStringSubmatch(t)
 		unsigned := strings.Contains(t, "unsigned")

--- a/parser_test.go
+++ b/parser_test.go
@@ -43,8 +43,11 @@ func TestParser_ParseType(t *testing.T) {
 		list := [][]interface{}{
 			{"date", "time.Time", "null.Time"},
 			{"datetime", "time.Time", "null.Time"},
+			{"datetime(6)", "time.Time", "null.Time"},
 			{"timestamp", "time.Time", "null.Time"},
+			{"timestamp(6)", "time.Time", "null.Time"},
 			{"time", "string", "null.String"},
+			{"time(6)", "string", "null.String"},
 		}
 		for _, v := range list {
 			t := v[0].(string)


### PR DESCRIPTION
MySQL 5.6 has fractional seconds support for TIME, DATETIME, and TIMESTAMP values, with up to microseconds (6 digits) precision.
So I added it to the type that can be parsed.

## Refs
https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html

