### PR TITLE
fix: JSON type columns are now mapped to null.JSON

### DIFF
--- a/mapper_test.go
+++ b/mapper_test.go
@@ -94,7 +94,7 @@ func setupFields(t *testing.T, db DB) (*model.Fields, func()) {
 		LongblobField:                  longblob,
 		LongblobNullField:              null.BytesFrom(longblob),
 		JsonField:                      json,
-		JsonNullField:                  null.BytesFrom(json),
+		JsonNullField:                  null.JSONFrom(json),
 	}
 	_, err := db.Insert(&field)
 	assert.False(t, field.Id == 0)
@@ -157,7 +157,7 @@ func assertFields(t *testing.T, dest *model.Fields, field *model.Fields) {
 	assert.ElementsMatch(t, dest.LongblobField, field.LongblobField)
 	assert.ElementsMatch(t, dest.LongblobNullField.Bytes, field.LongblobNullField.Bytes)
 	assert.JSONEq(t, string(dest.JsonField), string(field.JsonField))
-	assert.JSONEq(t, string(dest.JsonNullField.Bytes), string(field.JsonNullField.Bytes))
+	assert.JSONEq(t, string(dest.JsonNullField.JSON), string(field.JsonNullField.JSON))
 }
 func TestMapper_MapMany(t *testing.T) {
 	db := testDb()

--- a/model/fields.go
+++ b/model/fields.go
@@ -62,7 +62,7 @@ type Fields struct {
 	LongblobField                  []byte       `exql:"column:longblob_field;type:longblob;not null" json:"longblob_field"`
 	LongblobNullField              null.Bytes   `exql:"column:longblob_null_field;type:longblob" json:"longblob_null_field"`
 	JsonField                      []byte       `exql:"column:json_field;type:json;not null" json:"json_field"`
-	JsonNullField                  null.Bytes   `exql:"column:json_null_field;type:json" json:"json_null_field"`
+	JsonNullField                  null.JSON    `exql:"column:json_null_field;type:json" json:"json_null_field"`
 }
 
 func (f *Fields) TableName() string {

--- a/parser.go
+++ b/parser.go
@@ -225,7 +225,7 @@ func (p *parser) ParseType(t string, nullable bool) (string, error) {
 		return "[]byte", nil
 	} else if jsonPat.MatchString(t) {
 		if nullable {
-			return "null.Bytes", nil
+			return "null.JSON", nil
 		}
 		return "[]byte", nil
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -86,6 +86,6 @@ func TestParser_ParseType(t *testing.T) {
 	})
 	t.Run("json", func(t *testing.T) {
 		assertType("json", false, "[]byte")
-		assertType("json", true, "null.Bytes")
+		assertType("json", true, "null.JSON")
 	})
 }


### PR DESCRIPTION
JSON type columns are now mapped to `null.JSON` instead of `null.Bytes`