### PR TITLE
bump: go@1.16

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.14"
+          go-version: "1.16"
       - name: Check fmt
         run: |
           make fmt

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,7 +1,6 @@
 package exql
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,7 +12,7 @@ func TestGenerator_Generate(t *testing.T) {
 	db := testDb()
 	g := NewGenerator(db.DB())
 	checkFiles := func(dir string, elements []string) {
-		entries, err := ioutil.ReadDir(dir)
+		entries, err := os.ReadDir(dir)
 		assert.Nil(t, err)
 		var files []string
 		for _, e := range entries {
@@ -22,8 +21,9 @@ func TestGenerator_Generate(t *testing.T) {
 		assert.ElementsMatch(t, files, elements)
 	}
 	t.Run("bsaic", func(t *testing.T) {
-		dir, _ := ioutil.TempDir(os.TempDir(), "dist")
-		err := g.Generate(&GenerateOptions{
+		dir, err := os.MkdirTemp(os.TempDir(), "dist")
+		assert.Nil(t, err)
+		err = g.Generate(&GenerateOptions{
 			OutDir:  dir,
 			Package: "dist",
 		})
@@ -34,7 +34,7 @@ func TestGenerator_Generate(t *testing.T) {
 		checkFiles(dir, []string{"users.go", "user_groups.go", "group_users.go", "fields.go"})
 	})
 	t.Run("exclude", func(t *testing.T) {
-		dir, _ := ioutil.TempDir(os.TempDir(), "dist")
+		dir, _ := os.MkdirTemp(os.TempDir(), "dist")
 		err := g.Generate(&GenerateOptions{
 			OutDir:  dir,
 			Package: "dist",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/loilo-inc/exql
 
-go 1.14
+go 1.16
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -42,12 +42,10 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
 github.com/smartystreets/gunit v1.0.0/go.mod h1:qwPWnhz6pn0NnRBP++URONOVyNkPyr4SauJk4cUOwJs=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/tj/assert v0.0.0-20171129193455-018094318fb0 h1:Rw8kxzWo1mr6FSaYXjQELRe88y2KdfynXdnK72rdjtA=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=

--- a/tool/main.go
+++ b/tool/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"text/template"
 )
@@ -27,7 +26,7 @@ func main() {
 }
 
 func catFile(f string) string {
-	s, err := ioutil.ReadFile("example/" + f)
+	s, err := os.ReadFile("example/" + f)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- Replaced `io/ioutil` with alternatives.