### PR TITLE
Update go.mod to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ package main
 
 import (
 	"github.com/apex/log"
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 	"time"
 )
 
@@ -39,7 +39,7 @@ func OpenDB() exql.DB {
 package main
 
 import (
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 	"log"
 )
 
@@ -98,7 +98,7 @@ package main
 
 import (
 	"github.com/apex/log"
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 )
 
 func Update() {
@@ -162,7 +162,7 @@ package main
 
 import (
 	"github.com/apex/log"
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 )
 
 type School struct {
@@ -226,7 +226,7 @@ package main
 
 import (
 	"github.com/apex/log"
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 )
 
 func MapSerialOuterJoin() {
@@ -271,8 +271,8 @@ package main
 import (
 	"context"
 	"database/sql"
-	"github.com/loilo-inc/exql"
-	"github.com/loilo-inc/exql/model"
+	"github.com/loilo-inc/exql/v2"
+	"github.com/loilo-inc/exql/v2/model"
 	"github.com/volatiletech/null"
 	"time"
 )

--- a/example/db.go
+++ b/example/db.go
@@ -1,5 +1,5 @@
 package main
 
-import "github.com/loilo-inc/exql"
+import "github.com/loilo-inc/exql/v2"
 
 var db exql.DB

--- a/example/generator.go
+++ b/example/generator.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 	"log"
 )
 

--- a/example/open.go
+++ b/example/open.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/apex/log"
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 	"time"
 )
 

--- a/example/outer_join.go
+++ b/example/outer_join.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/apex/log"
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 )
 
 func MapSerialOuterJoin() {

--- a/example/serial_mapper.go
+++ b/example/serial_mapper.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/apex/log"
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 )
 
 type School struct {

--- a/example/tx.go
+++ b/example/tx.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"database/sql"
-	"github.com/loilo-inc/exql"
-	"github.com/loilo-inc/exql/model"
+	"github.com/loilo-inc/exql/v2"
+	"github.com/loilo-inc/exql/v2/model"
 	"github.com/volatiletech/null"
 	"time"
 )

--- a/example/update.go
+++ b/example/update.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/apex/log"
-	"github.com/loilo-inc/exql"
+	"github.com/loilo-inc/exql/v2"
 )
 
 func Update() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/loilo-inc/exql
+module github.com/loilo-inc/exql/v2
 
 go 1.16
 

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/loilo-inc/exql/model"
+	"github.com/loilo-inc/exql/v2/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/volatiletech/null"
 )

--- a/saver_test.go
+++ b/saver_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/loilo-inc/exql/model"
+	"github.com/loilo-inc/exql/v2/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/volatiletech/null"
 	"testing"

--- a/tx_test.go
+++ b/tx_test.go
@@ -3,7 +3,7 @@ package exql
 import (
 	"context"
 	"fmt"
-	"github.com/loilo-inc/exql/model"
+	"github.com/loilo-inc/exql/v2/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/volatiletech/null"
 	"testing"


### PR DESCRIPTION
fix

```
$ go get -u github.com/loilo-inc/exql/v2
go: github.com/loilo-inc/exql/v2@v2.0.0-rc1: go.mod has non-.../v2 module path "github.com/loilo-inc/exql" (and .../v2/go.mod does not exist) at revision v2.0.0-rc1
```

ref: https://christina04.hatenablog.com/entry/go-modules-major-version