### PR TITLE
fix: MapRowSerial for null.Type column

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -298,7 +298,11 @@ func mapRowSerial(
 			col := cols[colIndex]
 			if fIndex, ok := fields[col.Name()]; ok {
 				f := model.Elem().Field(fIndex)
-				f.Set(reflect.ValueOf(destVals[colIndex]).Elem().Elem())
+				if t := reflect.ValueOf(destVals[colIndex]).Elem(); t.IsNil() {
+					f.Set(reflect.Zero(t.Type().Elem())) // To set (*null.Type)(nil) as null.Type{}
+				} else {
+					f.Set(reflect.ValueOf(destVals[colIndex]).Elem().Elem())
+				}
 			}
 		}
 		dest.Set(model) // dest = *Model

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -468,6 +468,31 @@ ORDER BY users.id
 		assert.Equal(t, (*model.UserGroups)(nil), groups[1])
 	})
 
+	t.Run("fields", func(t *testing.T) {
+		field, reset := setupFields(t, db)
+		defer reset()
+
+		t.Run("struct", func(t *testing.T) {
+			rows, err := db.DB().Query(`SELECT * FROM fields WHERE id = ?`, field.Id)
+			assert.Nil(t, err)
+			var dest model.Fields
+			assert.True(t, rows.Next())
+			err = m.Map(rows, &dest)
+			assert.Nil(t, err)
+			assertFields(t, &dest, field)
+		})
+
+		t.Run("*struct", func(t *testing.T) {
+			rows, err := db.DB().Query(`SELECT * FROM fields WHERE id = ?`, field.Id)
+			assert.Nil(t, err)
+			var dest *model.Fields
+			assert.True(t, rows.Next())
+			err = m.Map(rows, &dest)
+			assert.Nil(t, err)
+			assertFields(t, dest, field)
+		})
+	})
+
 	t.Run("should return error if head column is not found", func(t *testing.T) {
 		t.Run("inner join case", func(t *testing.T) {
 			query := `

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -467,7 +467,6 @@ ORDER BY users.id
 		assert.Equal(t, user3.Id, users[1].Id)
 		assert.Equal(t, (*model.UserGroups)(nil), groups[1])
 	})
-
 	t.Run("fields", func(t *testing.T) {
 		field, reset := setupFields(t, db)
 		defer reset()
@@ -481,7 +480,6 @@ ORDER BY users.id
 			assert.Nil(t, err)
 			assertFields(t, &dest, field)
 		})
-
 		t.Run("*struct", func(t *testing.T) {
 			rows, err := db.DB().Query(`SELECT * FROM fields WHERE id = ?`, field.Id)
 			assert.Nil(t, err)
@@ -492,7 +490,6 @@ ORDER BY users.id
 			assertFields(t, dest, field)
 		})
 	})
-
 	t.Run("should return error if head column is not found", func(t *testing.T) {
 		t.Run("inner join case", func(t *testing.T) {
 			query := `


### PR DESCRIPTION
* Fix panic caused by trying to set `(*null.Type)(nil)` to `null.Type`

