### PR TITLE
fix: check rows.Err() after rows.Next()

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -73,6 +73,9 @@ func (d *generator) Generate(opts *GenerateOptions) error {
 		tables = append(tables, table)
 	EOL:
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
 	for _, table := range tables {
 		if err := d.generateModelFile(table, opts); err != nil {
 			return err

--- a/mapper.go
+++ b/mapper.go
@@ -79,6 +79,9 @@ func (m *mapper) Map(row *sql.Rows, pointerOfStruct interface{}) error {
 	if row.Next() {
 		return mapRow(row, &destValue)
 	}
+	if err := row.Err(); err != nil {
+		return err
+	}
 	err := row.Close()
 	if err != nil {
 		return err
@@ -125,6 +128,9 @@ func (m *mapper) MapMany(rows *sql.Rows, structPtrOrSlicePtr interface{}) error 
 		// *dest = append(*dest, i)
 		destValue.Elem().Set(reflect.Append(destValue.Elem(), modelValue.Addr()))
 		cnt++
+	}
+	if err := rows.Err(); err != nil {
+		return err
 	}
 	err := rows.Close()
 	if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -152,6 +152,9 @@ func (p *parser) ParseTable(db *sql.DB, table string) (*Table, error) {
 		})
 		i++
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return &Table{
 		TableName: table,
 		Columns:   cols,


### PR DESCRIPTION
`ErrRecordNotFound` was returned if an error occurred in `rows.Next()`. So fixed to check `rows.Err()`.

### Refs
http://go-database-sql.org/errors.html