### PR TITLE
fix: Ignore ErrTxDone with Rollback().

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -3,6 +3,7 @@ package exql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 )
 
@@ -84,7 +85,9 @@ func transaction(db *sql.DB, ctx context.Context, opts *sql.TxOptions, callback 
 	}
 	if txErr != nil {
 		if err := sqlTx.Rollback(); err != nil {
-			return err
+			if !errors.Is(err, sql.ErrTxDone) {
+				return err
+			}
 		}
 		return txErr
 	} else if err := sqlTx.Commit(); err != nil {


### PR DESCRIPTION
https://pkg.go.dev/database/sql#DB.BeginTx
> If the context is canceled, the sql package will roll back the transaction.

Reading BeginTx, it seems that the sql package calls rollback if the context is canceled. In that case, when exql calls rollback, ErrTxDone is returned.
Therefore, if ErrTxDone is returned when reading rollback, the original error should be returned.