### PR TITLE
fix: model generation may fail on MySQL8

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -10,3 +10,13 @@ services:
       MYSQL_DATABASE: exql
     volumes:
       - ./schema:/docker-entrypoint-initdb.d
+  mysql8:
+    container_name: exql_mysql8
+    image: mysql:8
+    ports:
+      - 3327:3306
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+      MYSQL_DATABASE: exql
+    volumes:
+      - ./schema:/docker-entrypoint-initdb.d

--- a/generator_test.go
+++ b/generator_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 func TestGenerator_Generate(t *testing.T) {
-	for version, db := range testDbs() {
+	for version, db := range map[string]DB{
+		"mysql5.7": testDb(),
+		"mysql8":   testDbMySQL8(),
+	} {
 		t.Run(version, func(t *testing.T) {
 			g := NewGenerator(db.DB())
 			checkFiles := func(dir string, elements []string) {

--- a/generator_test.go
+++ b/generator_test.go
@@ -11,59 +11,62 @@ import (
 )
 
 func TestGenerator_Generate(t *testing.T) {
-	db := testDb()
-	g := NewGenerator(db.DB())
-	checkFiles := func(dir string, elements []string) {
-		entries, err := os.ReadDir(dir)
-		assert.Nil(t, err)
-		var files []string
-		for _, e := range entries {
-			files = append(files, e.Name())
-		}
-		assert.ElementsMatch(t, files, elements)
+	for version, db := range testDbs() {
+		t.Run(version, func(t *testing.T) {
+			g := NewGenerator(db.DB())
+			checkFiles := func(dir string, elements []string) {
+				entries, err := os.ReadDir(dir)
+				assert.Nil(t, err)
+				var files []string
+				for _, e := range entries {
+					files = append(files, e.Name())
+				}
+				assert.ElementsMatch(t, files, elements)
+			}
+			t.Run("basic", func(t *testing.T) {
+				dir, err := os.MkdirTemp(os.TempDir(), "dist")
+				assert.Nil(t, err)
+				err = g.Generate(&GenerateOptions{
+					OutDir:  dir,
+					Package: "dist",
+				})
+				if err != nil {
+					log.Errorf(err.Error())
+				}
+				assert.Nil(t, err)
+				checkFiles(dir, []string{"users.go", "user_groups.go", "user_login_histories.go", "group_users.go", "fields.go"})
+			})
+			t.Run("exclude", func(t *testing.T) {
+				dir, _ := os.MkdirTemp(os.TempDir(), "dist")
+				err := g.Generate(&GenerateOptions{
+					OutDir:  dir,
+					Package: "dist",
+					Exclude: []string{"fields"},
+				})
+				if err != nil {
+					log.Errorf(err.Error())
+				}
+				assert.Nil(t, err)
+				checkFiles(dir, []string{"users.go", "user_groups.go", "user_login_histories.go", "group_users.go"})
+			})
+
+			t.Run("should return error when rows.Error() return error", func(t *testing.T) {
+				mockDb, mock, err := sqlmock.New()
+				assert.NoError(t, err)
+				defer mockDb.Close()
+
+				mock.ExpectQuery(`show tables`).WillReturnRows(
+					sqlmock.NewRows([]string{"tables"}).
+						AddRow("users").
+						RowError(0, fmt.Errorf("err")))
+
+				dir, err := os.MkdirTemp(os.TempDir(), "dist")
+				assert.NoError(t, err)
+				assert.EqualError(t, NewGenerator(mockDb).Generate(&GenerateOptions{
+					OutDir:  dir,
+					Package: "dist",
+				}), "err")
+			})
+		})
 	}
-	t.Run("basic", func(t *testing.T) {
-		dir, err := os.MkdirTemp(os.TempDir(), "dist")
-		assert.Nil(t, err)
-		err = g.Generate(&GenerateOptions{
-			OutDir:  dir,
-			Package: "dist",
-		})
-		if err != nil {
-			log.Errorf(err.Error())
-		}
-		assert.Nil(t, err)
-		checkFiles(dir, []string{"users.go", "user_groups.go", "user_login_histories.go", "group_users.go", "fields.go"})
-	})
-	t.Run("exclude", func(t *testing.T) {
-		dir, _ := os.MkdirTemp(os.TempDir(), "dist")
-		err := g.Generate(&GenerateOptions{
-			OutDir:  dir,
-			Package: "dist",
-			Exclude: []string{"fields"},
-		})
-		if err != nil {
-			log.Errorf(err.Error())
-		}
-		assert.Nil(t, err)
-		checkFiles(dir, []string{"users.go", "user_groups.go", "user_login_histories.go", "group_users.go"})
-	})
-
-	t.Run("should return error when rows.Error() return error", func(t *testing.T) {
-		mockDb, mock, err := sqlmock.New()
-		assert.NoError(t, err)
-		defer mockDb.Close()
-
-		mock.ExpectQuery(`show tables`).WillReturnRows(
-			sqlmock.NewRows([]string{"tables"}).
-				AddRow("users").
-				RowError(0, fmt.Errorf("err")))
-
-		dir, err := os.MkdirTemp(os.TempDir(), "dist")
-		assert.NoError(t, err)
-		assert.EqualError(t, NewGenerator(mockDb).Generate(&GenerateOptions{
-			OutDir:  dir,
-			Package: "dist",
-		}), "err")
-	})
 }

--- a/parser.go
+++ b/parser.go
@@ -162,7 +162,7 @@ func (p *parser) ParseTable(db *sql.DB, table string) (*Table, error) {
 }
 
 func (p *parser) ParseType(t string, nullable bool) (string, error) {
-	intPat := regexp.MustCompile("^(tiny|small|medium|big)?int\\(\\d+?\\)( unsigned)?( zerofill)?$")
+	intPat := regexp.MustCompile("^(tiny|small|medium|big)?int(\\(\\d+?\\))?( unsigned)?( zerofill)?$")
 	floatPat := regexp.MustCompile("^float$")
 	doublePat := regexp.MustCompile("^double$")
 	charPat := regexp.MustCompile("^(var)?char\\(\\d+?\\)$")

--- a/test_db.go
+++ b/test_db.go
@@ -13,13 +13,6 @@ func testDb() DB {
 	return db
 }
 
-func testDbs() map[string]DB {
-	return map[string]DB{
-		"mysql5.7": testDb(),
-		"mysql8":   testDbMySQL8(),
-	}
-}
-
 func testDbMySQL8() DB {
 	db, err := Open(&OpenOptions{
 		Url: "root:@tcp(127.0.0.1:3327)/exql?charset=utf8mb4&parseTime=True&loc=Local",

--- a/test_db.go
+++ b/test_db.go
@@ -13,6 +13,23 @@ func testDb() DB {
 	return db
 }
 
+func testDbs() map[string]DB {
+	return map[string]DB{
+		"mysql5.7": testDb(),
+		"mysql8":   testDbMySQL8(),
+	}
+}
+
+func testDbMySQL8() DB {
+	db, err := Open(&OpenOptions{
+		Url: "root:@tcp(127.0.0.1:3327)/exql?charset=utf8mb4&parseTime=True&loc=Local",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return db
+}
+
 func testSqlDB() *sql.DB {
 	db, err := sql.Open("mysql", "root:@tcp(127.0.0.1:3326)/exql?charset=utf8mb4&parseTime=True&loc=Local")
 	if err != nil {


### PR DESCRIPTION
`error unknown type: int ` may happen on MySQL 8 because there is no `(length)` in schema

* mysql 5.7 example

```sql
  `int_field` int(11) NOT NULL,
  `bigint_field` bigint(20) NOT NULL,
```

* mysql 8 example

```sql
  `int_field` int NOT NULL,
  `bigint_field` bigint NOT NULL,
```