### PR TITLE
feat: Finder

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.18"
-      - run: make updb
+      - run: make up
       - name: Check generated codes
         run: |
           go install

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-updb:
+up:down
 	docker-compose -f docker-compose.db.yml up -d
 down:
 	docker-compose -f docker-compose.db.yml down

--- a/README.md
+++ b/README.md
@@ -285,11 +285,19 @@ Other queries should be executed by `sql.DB` that got from `DB`.
 ```go
 package main
 
-import "github.com/loilo-inc/exql/v2"
+import (
+	"log"
 
-// db.DB() returns *sql.DB
+	"github.com/loilo-inc/exql/v2"
+)
+
+// To execute other kind of queries, unwrap sql.DB.
 func OtherQuery(db exql.DB) {
-	db.DB().Exec("SELECT * FROM users LIMIT 10")
+	// db.DB() returns *sql.DB
+	row := db.DB().QueryRow("SELECT COUNT(*) FROM users")
+	var count int
+	row.Scan(&count)
+	log.Printf("%d", count)
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -343,39 +343,31 @@ import (
 
 	"github.com/loilo-inc/exql/v2"
 	"github.com/loilo-inc/exql/v2/model"
+	"github.com/loilo-inc/exql/v2/query"
 )
 
-func Map(db exql.DB) {
-	// select query
-	rows, err := db.DB().Query(`SELECT * FROM users WHERE id = ?`, 1)
+func Find(db exql.DB) {
+	// Destination model struct
+	var user model.Users
+	// Pass as a pointer
+	err := db.Find(query.Q(`SELECT * FROM users WHERE id = ?`, 1), &user)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// Destination model struct
-		var user model.Users
-		// Passing destination to Map(). The second argument must be a pointer of the model.
-		if err := db.Map(rows, &user); err != nil {
-			log.Fatal(err)
-		}
-		log.Printf("%d", user.Id) // -> 1
 	}
+	log.Printf("%d", user.Id) // -> 1
 }
 
-func MapMany(db exql.DB) {
-	rows, err := db.DB().Query(`SELECT * FROM users LIMIT ?`, 5)
+func FindMany(db exql.DB) {
+	// Destination slice of models.
+	// NOTE: It must be the slice of pointers of models.
+	var users []*model.Users
+	// Passing destination to MapMany().
+	// Second argument must be a pointer.
+	err := db.FindMany(query.Q(`SELECT * FROM users LIMIT ?`, 5), &users)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// Destination slice of models.
-		// NOTE: It must be the slice of pointers of models.
-		var users []*model.Users
-		// Passing destination to MapMany().
-		// Second argument must be a pointer.
-		if err := db.MapMany(rows, &users); err != nil {
-			log.Fatal(err)
-		}
-		log.Printf("%d", len(users)) // -> 5
 	}
+	log.Printf("%d", len(users)) // -> 5
 }
 
 ```

--- a/db.go
+++ b/db.go
@@ -13,6 +13,7 @@ import (
 
 type DB interface {
 	Saver
+	Mapper
 	Finder
 	// DB returns *sql.DB object.
 	DB() *sql.DB
@@ -202,4 +203,14 @@ func (d *db) FindMany(q q.Query, destSlicePtrOfStruct any) error {
 // FindManyContext implements DB
 func (d *db) FindManyContext(ctx context.Context, q q.Query, destSlicePtrOfStruct any) error {
 	return d.f.FindManyContext(ctx, q, destSlicePtrOfStruct)
+}
+
+// Deprecated: Use Find or MapRow. It will be removed in next version.
+func (d *db) Map(rows *sql.Rows, destPtr any) error {
+	return MapRow(rows, destPtr)
+}
+
+// Deprecated: Use FindContext or MapRows. It will be removed in next version.
+func (d *db) MapMany(rows *sql.Rows, destSlicePtr any) error {
+	return MapRows(rows, destSlicePtr)
 }

--- a/example/mapper.go
+++ b/example/mapper.go
@@ -5,37 +5,29 @@ import (
 
 	"github.com/loilo-inc/exql/v2"
 	"github.com/loilo-inc/exql/v2/model"
+	"github.com/loilo-inc/exql/v2/query"
 )
 
-func Map(db exql.DB) {
-	// select query
-	rows, err := db.DB().Query(`SELECT * FROM users WHERE id = ?`, 1)
+func Find(db exql.DB) {
+	// Destination model struct
+	var user model.Users
+	// Pass as a pointer
+	err := db.Find(query.Q(`SELECT * FROM users WHERE id = ?`, 1), &user)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// Destination model struct
-		var user model.Users
-		// Passing destination to Map(). The second argument must be a pointer of the model.
-		if err := db.Map(rows, &user); err != nil {
-			log.Fatal(err)
-		}
-		log.Printf("%d", user.Id) // -> 1
 	}
+	log.Printf("%d", user.Id) // -> 1
 }
 
-func MapMany(db exql.DB) {
-	rows, err := db.DB().Query(`SELECT * FROM users LIMIT ?`, 5)
+func FindMany(db exql.DB) {
+	// Destination slice of models.
+	// NOTE: It must be the slice of pointers of models.
+	var users []*model.Users
+	// Passing destination to MapMany().
+	// Second argument must be a pointer.
+	err := db.FindMany(query.Q(`SELECT * FROM users LIMIT ?`, 5), &users)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// Destination slice of models.
-		// NOTE: It must be the slice of pointers of models.
-		var users []*model.Users
-		// Passing destination to MapMany().
-		// Second argument must be a pointer.
-		if err := db.MapMany(rows, &users); err != nil {
-			log.Fatal(err)
-		}
-		log.Printf("%d", len(users)) // -> 5
 	}
+	log.Printf("%d", len(users)) // -> 5
 }

--- a/example/other.go
+++ b/example/other.go
@@ -1,8 +1,16 @@
 package main
 
-import "github.com/loilo-inc/exql/v2"
+import (
+	"log"
 
-// db.DB() returns *sql.DB
+	"github.com/loilo-inc/exql/v2"
+)
+
+// To execute other kind of queries, unwrap sql.DB.
 func OtherQuery(db exql.DB) {
-	db.DB().Exec("SELECT * FROM users LIMIT 10")
+	// db.DB() returns *sql.DB
+	row := db.DB().QueryRow("SELECT COUNT(*) FROM users")
+	var count int
+	row.Scan(&count)
+	log.Printf("%d", count)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,6 +1,8 @@
 package exql
 
 var ErrMapRowSerialDestination = errMapRowSerialDestination
+var ErrMapDestination = errMapDestination
+var ErrMapManyDestination = errMapManyDestination
 
 type Adb = db
 

--- a/export_test.go
+++ b/export_test.go
@@ -3,3 +3,7 @@ package exql
 var ErrMapRowSerialDestination = errMapRowSerialDestination
 
 type Adb = db
+
+func NewFinder(ex Executor) *finder {
+	return newFinder(ex)
+}

--- a/finder.go
+++ b/finder.go
@@ -1,0 +1,57 @@
+package exql
+
+import (
+	"context"
+
+	"github.com/loilo-inc/exql/v2/query"
+)
+
+// Finder is an interface to execute select query and map rows into the destination.
+type Finder interface {
+	Find(q query.Query, destPtrOfStruct any) error
+	FindContext(ctx context.Context, q query.Query, destPtrOfStruct any) error
+	FindMany(q query.Query, destSlicePtrOfStruct any) error
+	FindManyContext(ctx context.Context, q query.Query, destSlicePtrOfStruct any) error
+}
+
+type finder struct {
+	ex Executor
+}
+
+// Find implements Finder
+func (f *finder) Find(q query.Query, destPtrOfStruct any) error {
+	return f.FindContext(context.Background(), q, destPtrOfStruct)
+}
+
+// FindContext implements Finder
+func (f *finder) FindContext(ctx context.Context, q query.Query, destPtrOfStruct any) error {
+	if stmt, args, err := q.Query(); err != nil {
+		return err
+	} else if rows, err := f.ex.QueryContext(ctx, stmt, args...); err != nil {
+		return err
+	} else if err := MapRow(rows, destPtrOfStruct); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FindMany implements Finder
+func (f *finder) FindMany(q query.Query, destSlicePtrOfStruct any) error {
+	return f.FindManyContext(context.Background(), q, destSlicePtrOfStruct)
+}
+
+// FindManyContext implements Finder
+func (f *finder) FindManyContext(ctx context.Context, q query.Query, destSlicePtrOfStruct any) error {
+	if stmt, args, err := q.Query(); err != nil {
+		return err
+	} else if rows, err := f.ex.QueryContext(ctx, stmt, args...); err != nil {
+		return err
+	} else if err := MapRows(rows, destSlicePtrOfStruct); err != nil {
+		return err
+	}
+	return nil
+}
+
+func newFinder(ex Executor) *finder {
+	return &finder{ex: ex}
+}

--- a/finder_test.go
+++ b/finder_test.go
@@ -1,0 +1,58 @@
+package exql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/loilo-inc/exql/v2"
+	"github.com/loilo-inc/exql/v2/mocks/mock_query"
+	"github.com/loilo-inc/exql/v2/model"
+	"github.com/loilo-inc/exql/v2/query"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFinder_Find(t *testing.T) {
+	t.Run("call FindContext", func(t *testing.T) {
+
+	})
+}
+
+func TestFinder_FindContext(t *testing.T) {
+	db := testDb()
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	user1 := model.Users{Name: "user1"}
+	user2 := model.Users{Name: "user2"}
+	db.Insert(&user1)
+	db.Insert(&user2)
+	t.Cleanup(func() {
+		db.Delete(
+			model.UsersTableName,
+			query.Cond("id in (:?)", query.V(user1.Id, user2.Id)),
+		)
+	})
+	f := exql.NewFinder(db.DB())
+	t.Run("basic", func(t *testing.T) {
+		var dest model.Users
+		err := f.FindContext(ctx, query.Q(`select * from users where id = ?`, user1.Id), &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, user1.Name, dest.Name)
+	})
+	t.Run("should error if query is invalid", func(t *testing.T) {
+		q := mock_query.NewMockQuery(ctrl)
+		q.EXPECT().Query().Return("", nil, fmt.Errorf("err"))
+		err := f.FindContext(ctx, q, nil)
+		assert.EqualError(t, err, "err")
+	})
+	t.Run("should error if query failed", func(t *testing.T) {
+		err := f.FindContext(ctx, query.Q(`select`), nil)
+		assert.Error(t, err)
+	})
+	t.Run("should error if mapping failed", func(t *testing.T) {
+		var dest model.Users
+		err := f.FindContext(ctx, query.Q(`select * from users where id = -1`), &dest)
+		assert.ErrorIs(t, err, exql.ErrRecordNotFound)
+	})
+}

--- a/finder_test.go
+++ b/finder_test.go
@@ -1,7 +1,6 @@
 package exql_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -13,15 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFinder_Find(t *testing.T) {
-	t.Run("call FindContext", func(t *testing.T) {
-
-	})
-}
-
-func TestFinder_FindContext(t *testing.T) {
+func TestFinder(t *testing.T) {
 	db := testDb()
-	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	user1 := model.Users{Name: "user1"}
 	user2 := model.Users{Name: "user2"}
@@ -30,29 +22,55 @@ func TestFinder_FindContext(t *testing.T) {
 	t.Cleanup(func() {
 		db.Delete(
 			model.UsersTableName,
-			query.Cond("id in (:?)", query.V(user1.Id, user2.Id)),
+			query.Cond("id in (?,?)", user1.Id, user2.Id),
 		)
 	})
 	f := exql.NewFinder(db.DB())
-	t.Run("basic", func(t *testing.T) {
-		var dest model.Users
-		err := f.FindContext(ctx, query.Q(`select * from users where id = ?`, user1.Id), &dest)
-		assert.NoError(t, err)
-		assert.Equal(t, user1.Name, dest.Name)
+	t.Run("FindContext", func(t *testing.T) {
+		t.Run("basic", func(t *testing.T) {
+			var dest model.Users
+			err := f.Find(query.Q(`select * from users where id = ?`, user1.Id), &dest)
+			assert.NoError(t, err)
+			assert.Equal(t, user1.Name, dest.Name)
+		})
+		t.Run("should error if query is invalid", func(t *testing.T) {
+			q := mock_query.NewMockQuery(ctrl)
+			q.EXPECT().Query().Return("", nil, fmt.Errorf("err"))
+			err := f.Find(q, nil)
+			assert.EqualError(t, err, "err")
+		})
+		t.Run("should error if query failed", func(t *testing.T) {
+			err := f.Find(query.Q(`select`), nil)
+			assert.Error(t, err)
+		})
+		t.Run("should error if mapping failed", func(t *testing.T) {
+			var dest model.Users
+			err := f.Find(query.Q(`select * from users where id = -1`), &dest)
+			assert.ErrorIs(t, err, exql.ErrRecordNotFound)
+		})
 	})
-	t.Run("should error if query is invalid", func(t *testing.T) {
-		q := mock_query.NewMockQuery(ctrl)
-		q.EXPECT().Query().Return("", nil, fmt.Errorf("err"))
-		err := f.FindContext(ctx, q, nil)
-		assert.EqualError(t, err, "err")
-	})
-	t.Run("should error if query failed", func(t *testing.T) {
-		err := f.FindContext(ctx, query.Q(`select`), nil)
-		assert.Error(t, err)
-	})
-	t.Run("should error if mapping failed", func(t *testing.T) {
-		var dest model.Users
-		err := f.FindContext(ctx, query.Q(`select * from users where id = -1`), &dest)
-		assert.ErrorIs(t, err, exql.ErrRecordNotFound)
+	t.Run("FindManyContext", func(t *testing.T) {
+		t.Run("basic", func(t *testing.T) {
+			var dest []*model.Users
+			err := f.FindMany(query.Q(`select * from users where id in (?,?)`, user1.Id, user2.Id), &dest)
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(dest))
+			assert.ElementsMatch(t, []int64{user1.Id, user2.Id}, []int64{dest[0].Id, dest[1].Id})
+		})
+		t.Run("should error if query is invalid", func(t *testing.T) {
+			q := mock_query.NewMockQuery(ctrl)
+			q.EXPECT().Query().Return("", nil, fmt.Errorf("err"))
+			err := f.FindMany(q, nil)
+			assert.EqualError(t, err, "err")
+		})
+		t.Run("should error if query failed", func(t *testing.T) {
+			err := f.FindMany(query.Q(`select`), nil)
+			assert.Error(t, err)
+		})
+		t.Run("should error if mapping failed", func(t *testing.T) {
+			var dest []*model.Users
+			err := f.FindMany(query.Q(`select * from users where id = -1`), &dest)
+			assert.ErrorIs(t, err, exql.ErrRecordNotFound)
+		})
 	})
 }

--- a/mapper.go
+++ b/mapper.go
@@ -7,34 +7,6 @@ import (
 	"reflect"
 )
 
-type Mapper interface {
-	// Map reads data from a single row and maps those columns into the destination struct.
-	// pointerOfStruct MUST BE a pointer of the struct.
-	// It closes rows after mapping regardless of whether an error occurred.
-	//
-	// Example:
-	//
-	//	var user User
-	//	err := m.Map(rows, &user)
-	Map(rows *sql.Rows, pointerOfStruct interface{}) error
-	// MapMany reads all rows and maps columns for each destination struct.
-	// pointerOfSliceOfStruct MUST BE a pointer of the slice of a pointer of the struct.
-	// It closes rows after mapping regardless of whether an error occurred.
-	//
-	// Example:
-	//
-	//	var users []*Users
-	//	m.MapMany(rows, &users)
-	MapMany(rows *sql.Rows, pointerOfSliceOfStruct interface{}) error
-}
-
-type mapper struct {
-}
-
-func NewMapper() Mapper {
-	return &mapper{}
-}
-
 // Error returned when record not found
 var ErrRecordNotFound = errors.New("record not found")
 
@@ -68,7 +40,15 @@ func mapDestinationError() error {
 	return fmt.Errorf("destination must be pointer of struct")
 }
 
-func (m *mapper) Map(row *sql.Rows, pointerOfStruct interface{}) error {
+// MapRow reads data from single row and maps those columns into destination struct.
+// pointerOfStruct MUST BE a pointer of struct.
+// It closes rows after mapping regardless error occurred.
+//
+// Example:
+//
+//	var user User
+//	err := m.Map(rows, &user)
+func MapRow(row *sql.Rows, pointerOfStruct interface{}) error {
 	defer func() {
 		if row != nil {
 			row.Close()
@@ -103,7 +83,15 @@ func mapManyDestinationError() error {
 	return fmt.Errorf("destination must be pointer of slice of struct")
 }
 
-func (m *mapper) MapMany(rows *sql.Rows, structPtrOrSlicePtr interface{}) error {
+// MapRows reads all rows and maps columns for each destination struct.
+// pointerOfSliceOfStruct MUST BE a pointer of slice of pointer of struct.
+// It closes rows after mapping regardless error occurred.
+//
+// Example:
+//
+//	var users []*Users
+//	m.MapMany(rows, &users)
+func MapRows(rows *sql.Rows, structPtrOrSlicePtr interface{}) error {
 	defer func() {
 		if rows != nil {
 			rows.Close()

--- a/mapper.go
+++ b/mapper.go
@@ -10,6 +10,14 @@ import (
 // Error returned when record not found
 var ErrRecordNotFound = errors.New("record not found")
 
+// Deprecated: Use Finder It will be removed in next version.
+type Mapper interface {
+	// Deprecated: Use Find or MapRow. It will be removed in next version.
+	Map(rows *sql.Rows, destPtr any) error
+	// Deprecated: Use FindContext or MapRows. It will be removed in next version.
+	MapMany(rows *sql.Rows, destSlicePtr any) error
+}
+
 type ColumnSplitter func(i int) string
 
 // SerialMapper is an interface for mapping a joined row into one or more destinations serially.
@@ -80,7 +88,7 @@ func MapRow(row *sql.Rows, pointerOfStruct interface{}) error {
 }
 
 func mapManyDestinationError() error {
-	return fmt.Errorf("destination must be pointer of slice of struct")
+	return fmt.Errorf("destination must be a pointer of slice of struct")
 }
 
 // MapRows reads all rows and maps columns for each destination struct.

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -198,9 +198,7 @@ func TestMapper_MapRows(t *testing.T) {
 	})
 	t.Run("should return error if destination is not pointer of slice of pointer of struct", func(t *testing.T) {
 		doTest := func(i interface{}) {
-			assert.EqualError(t, exql.MapRows(nil, i),
-				"destination must be pointer of slice of struct",
-			)
+			assert.ErrorIs(t, exql.MapRows(nil, i), exql.ErrMapManyDestination)
 		}
 		t.Run("int", func(t *testing.T) {
 			doTest(0)
@@ -292,7 +290,7 @@ func TestMapper_Map(t *testing.T) {
 	})
 	t.Run("should return error if destination is not pointer of struct", func(t *testing.T) {
 		doTest := func(i interface{}) {
-			assert.EqualError(t, exql.MapRow(nil, i), "destination must be pointer of struct")
+			assert.ErrorIs(t, exql.MapRow(nil, i), exql.ErrMapDestination)
 		}
 		t.Run("int", func(t *testing.T) {
 			doTest(0)

--- a/saver.go
+++ b/saver.go
@@ -35,6 +35,10 @@ func NewSaver(ex Executor) Saver {
 	return &saver{ex: ex}
 }
 
+func newSaver(ex Executor) *saver {
+	return &saver{ex: ex}
+}
+
 func (s *saver) Insert(modelPtr Model) (sql.Result, error) {
 	return s.InsertContext(context.Background(), modelPtr)
 }

--- a/saver_test.go
+++ b/saver_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestSaver_Insert(t *testing.T) {
 	d := testDb()
-	m := exql.NewMapper()
 	s := exql.NewSaver(d.DB())
 	t.Run("basic", func(t *testing.T) {
 		user := &model.Users{
@@ -40,7 +39,7 @@ func TestSaver_Insert(t *testing.T) {
 		rows, err := d.DB().Query(`SELECT * FROM users WHERE id = ?`, lid)
 		assert.NoError(t, err)
 		var actual model.Users
-		err = m.Map(rows, &actual)
+		err = exql.MapRow(rows, &actual)
 		assert.NoError(t, err)
 		assert.Equal(t, lid, actual.Id)
 		assert.Equal(t, user.Name, actual.Name)
@@ -91,7 +90,6 @@ func TestSaver_Insert(t *testing.T) {
 
 func TestSaver_InsertContext(t *testing.T) {
 	d := testDb()
-	m := exql.NewMapper()
 	s := exql.NewSaver(d.DB())
 	t.Run("basic", func(t *testing.T) {
 		user := &model.Users{
@@ -112,7 +110,7 @@ func TestSaver_InsertContext(t *testing.T) {
 		rows, err := d.DB().Query(`SELECT * FROM users WHERE id = ?`, lid)
 		assert.NoError(t, err)
 		var actual model.Users
-		err = m.Map(rows, &actual)
+		err = exql.MapRow(rows, &actual)
 		assert.NoError(t, err)
 		assert.Equal(t, lid, actual.Id)
 		assert.Equal(t, user.Name, actual.Name)
@@ -138,7 +136,7 @@ func TestSaver_InsertContext(t *testing.T) {
 		rows, err := d.DB().Query(`SELECT * FROM user_login_histories WHERE id = ?`, lid)
 		assert.NoError(t, err)
 		var actual model.UserLoginHistories
-		err = m.Map(rows, &actual)
+		err = exql.MapRow(rows, &actual)
 		assert.NoError(t, err)
 		assert.Equal(t, lid, actual.Id)
 		assert.Equal(t, history.UserId, actual.UserId)
@@ -164,7 +162,7 @@ func TestSaver_InsertContext(t *testing.T) {
 		rows, err := d.DB().Query(`SELECT * FROM user_login_histories WHERE id = ?`, lid)
 		assert.NoError(t, err)
 		var actual model.UserLoginHistories
-		err = m.Map(rows, &actual)
+		err = exql.MapRow(rows, &actual)
 		assert.NoError(t, err)
 		assert.Equal(t, lid, actual.Id)
 		assert.Equal(t, history.UserId, actual.UserId)
@@ -189,7 +187,7 @@ func TestSaver_InsertContext(t *testing.T) {
 		rows, err := d.DB().Query(`SELECT * FROM users WHERE id = ?`, lid)
 		assert.NoError(t, err)
 		var actual model.Users
-		err = m.Map(rows, &actual)
+		err = exql.MapRow(rows, &actual)
 		assert.NoError(t, err)
 		assert.Equal(t, lid, actual.Id)
 		assert.Equal(t, user.Name, actual.Name)
@@ -199,7 +197,6 @@ func TestSaver_InsertContext(t *testing.T) {
 
 func TestSaver_Update(t *testing.T) {
 	d := testDb()
-	m := exql.NewMapper()
 	s := exql.NewSaver(d.DB())
 	t.Run("basic", func(t *testing.T) {
 		result, err := d.DB().Exec(
@@ -222,7 +219,7 @@ func TestSaver_Update(t *testing.T) {
 		var actual model.Users
 		rows, err := d.DB().Query(`SELECT * FROM users WHERE id = ?`, lid)
 		assert.NoError(t, err)
-		err = m.Map(rows, &actual)
+		err = exql.MapRow(rows, &actual)
 		assert.NoError(t, err)
 		assert.Equal(t, "lang", actual.Name)
 		assert.Equal(t, int64(20), actual.Age)
@@ -299,7 +296,6 @@ func TestSaver_UpdateModelContext(t *testing.T) {
 
 func TestSaver_UpdateContext(t *testing.T) {
 	d := testDb()
-	m := exql.NewMapper()
 	s := exql.NewSaver(d.DB())
 	t.Run("basic", func(t *testing.T) {
 		result, err := d.DB().Exec(
@@ -322,7 +318,7 @@ func TestSaver_UpdateContext(t *testing.T) {
 		var actual model.Users
 		rows, err := d.DB().Query(`SELECT * FROM users WHERE id = ?`, lid)
 		assert.NoError(t, err)
-		err = m.Map(rows, &actual)
+		err = exql.MapRow(rows, &actual)
 		assert.NoError(t, err)
 		assert.Equal(t, "lang", actual.Name)
 		assert.Equal(t, int64(20), actual.Age)

--- a/tx.go
+++ b/tx.go
@@ -11,6 +11,7 @@ import (
 type Tx interface {
 	Saver
 	Finder
+	Mapper
 	Tx() *sql.Tx
 }
 
@@ -98,6 +99,16 @@ func (t *tx) FindMany(q q.Query, destSlicePtrOfStruct any) error {
 // FindManyContext implements DB
 func (t *tx) FindManyContext(ctx context.Context, q q.Query, destSlicePtrOfStruct any) error {
 	return t.f.FindManyContext(ctx, q, destSlicePtrOfStruct)
+}
+
+// Deprecated: Use Find or MapRow/MapRows. It will be removed in next version.
+func (t *tx) Map(rows *sql.Rows, destPtr any) error {
+	return MapRow(rows, destPtr)
+}
+
+// Deprecated: Use FindContext or MapRow/MapRows. It will be removed in next version.
+func (t *tx) MapMany(rows *sql.Rows, destSlicePtr any) error {
+	return MapRows(rows, destSlicePtr)
 }
 
 func (t *tx) Tx() *sql.Tx {

--- a/tx.go
+++ b/tx.go
@@ -10,14 +10,18 @@ import (
 
 type Tx interface {
 	Saver
-	Mapper
+	Finder
 	Tx() *sql.Tx
 }
 
 type tx struct {
-	s  Saver
-	m  Mapper
+	s  *saver
+	f  *finder
 	tx *sql.Tx
+}
+
+func newTx(t *sql.Tx) *tx {
+	return &tx{s: newSaver(t), f: newFinder(t), tx: t}
 }
 
 func (t *tx) Insert(modelPtr Model) (sql.Result, error) {
@@ -76,12 +80,24 @@ func (d *tx) QueryRowContext(ctx context.Context, query q.Query) (*sql.Row, erro
 	return d.s.QueryRowContext(ctx, query)
 }
 
-func (t *tx) Map(rows *sql.Rows, pointerOfStruct interface{}) error {
-	return t.m.Map(rows, pointerOfStruct)
+// Find implements DB
+func (t *tx) Find(q q.Query, destPtrOfStruct any) error {
+	return t.f.Find(q, destPtrOfStruct)
 }
 
-func (t *tx) MapMany(rows *sql.Rows, pointerOfSliceOfStruct interface{}) error {
-	return t.m.MapMany(rows, pointerOfSliceOfStruct)
+// FindContext implements DB
+func (t *tx) FindContext(ctx context.Context, q q.Query, destPtrOfStruct any) error {
+	return t.f.FindContext(ctx, q, destPtrOfStruct)
+}
+
+// FindMany implements DB
+func (t *tx) FindMany(q q.Query, destSlicePtrOfStruct any) error {
+	return t.f.FindMany(q, destSlicePtrOfStruct)
+}
+
+// FindManyContext implements DB
+func (t *tx) FindManyContext(ctx context.Context, q q.Query, destSlicePtrOfStruct any) error {
+	return t.f.FindManyContext(ctx, q, destSlicePtrOfStruct)
 }
 
 func (t *tx) Tx() *sql.Tx {
@@ -93,7 +109,7 @@ func Transaction(db *sql.DB, ctx context.Context, opts *sql.TxOptions, callback 
 	if err != nil {
 		return err
 	}
-	tx := &tx{tx: sqlTx, s: NewSaver(sqlTx), m: NewMapper()}
+	tx := newTx(sqlTx)
 	var p interface{}
 	txErr := func() error {
 		defer func() {


### PR DESCRIPTION
Deprecate `Mapper` and introduced new `Finder` interface.

```go
func Find(db exql.DB) {
	// Destination model struct
	var user model.Users
	// Pass as a pointer
	err := db.Find(query.Q(`SELECT * FROM users WHERE id = ?`, 1), &user)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("%d", user.Id) // -> 1
}

func FindMany(db exql.DB) {
	// Destination slice of models.
	// NOTE: It must be the slice of pointers of models.
	var users []*model.Users
	// Passing destination to MapMany().
	// Second argument must be a pointer.
	err := db.FindMany(query.Q(`SELECT * FROM users LIMIT ?`, 5), &users)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("%d", len(users)) // -> 5
}
```