### PR TITLE
feat: add custom opener for exql.Open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea
 dist
 coverage.out
-.vscode
 compose.yml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.go": "${capture}_test.go",
+    "go.mod": "go.sum"
+  }
+}

--- a/db_test.go
+++ b/db_test.go
@@ -1,9 +1,12 @@
 package exql_test
 
 import (
+	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/loilo-inc/exql/v2"
+	"github.com/loilo-inc/exql/v2/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,4 +20,37 @@ func TestNewDB(t *testing.T) {
 	d := testSqlDB()
 	db := exql.NewDB(d)
 	assert.Equal(t, d, db.DB())
+}
+
+func TestOpen(t *testing.T) {
+	t.Run("should call OpenContext", func(t *testing.T) {
+		d, err := exql.Open(&exql.OpenOptions{
+			Url: test.DbUrl,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.NotNil(t, d)
+	})
+}
+
+func TestOpenContext(t *testing.T) {
+	t.Run("should return error when url is empty", func(t *testing.T) {
+		_, err := exql.OpenContext(context.TODO(), &exql.OpenOptions{
+			Url: "",
+		})
+		assert.EqualError(t, err, "opts.Url is required")
+	})
+	t.Run("with custom opener", func(t *testing.T) {
+		var called bool
+		_, err := exql.OpenContext(context.TODO(), &exql.OpenOptions{
+			Url: test.DbUrl,
+			OpenFunc: func(driverName string, url string) (*sql.DB, error) {
+				called = true
+				return sql.Open(driverName, url)
+			},
+		})
+		assert.NoError(t, err)
+		assert.True(t, called)
+	})
 }

--- a/mapper.go
+++ b/mapper.go
@@ -19,6 +19,18 @@ type Mapper interface {
 	MapMany(rows *sql.Rows, destSlicePtr any) error
 }
 
+type mapper struct{}
+
+// Map reads data from single row and maps those columns into destination struct.
+func (m *mapper) Map(rows *sql.Rows, destPtr any) error {
+	return MapRow(rows, destPtr)
+}
+
+// MapMany reads all data from rows and maps those columns for each destination struct.
+func (m *mapper) MapMany(rows *sql.Rows, destSlicePtr any) error {
+	return MapRows(rows, destSlicePtr)
+}
+
 type ColumnSplitter func(i int) string
 
 // SerialMapper is an interface for mapping a joined row into one or more destinations serially.

--- a/test/db.go
+++ b/test/db.go
@@ -1,0 +1,3 @@
+package test
+
+const DbUrl = "root:@tcp(127.0.0.1:13326)/exql?charset=utf8mb4&parseTime=True&loc=Local"

--- a/test_db_test.go
+++ b/test_db_test.go
@@ -5,11 +5,12 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/loilo-inc/exql/v2"
+	"github.com/loilo-inc/exql/v2/test"
 )
 
 func testDb() exql.DB {
 	db, err := exql.Open(&exql.OpenOptions{
-		Url: "root:@tcp(127.0.0.1:13326)/exql?charset=utf8mb4&parseTime=True&loc=Local",
+		Url: test.DbUrl,
 	})
 	if err != nil {
 		panic(err)
@@ -18,7 +19,7 @@ func testDb() exql.DB {
 }
 
 func testSqlDB() *sql.DB {
-	db, err := sql.Open("mysql", "root:@tcp(127.0.0.1:13326)/exql?charset=utf8mb4&parseTime=True&loc=Local")
+	db, err := sql.Open("mysql", test.DbUrl)
 	if err != nil {
 		panic(err)
 	}

--- a/tool/composegen/main.go
+++ b/tool/composegen/main.go
@@ -20,7 +20,6 @@ func main() {
 		log.Fatalf("unsupported arch: %s", arch)
 	}
 	yml := fmt.Sprintf(`
-version: "3.7"
 services:
   mysql:
     container_name: exql_mysql8

--- a/tx.go
+++ b/tx.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/loilo-inc/exql/v2/query"
 	"golang.org/x/xerrors"
 )
 
@@ -16,99 +15,14 @@ type Tx interface {
 }
 
 type tx struct {
-	s  *saver
-	f  *finder
+	*saver
+	*finder
+	*mapper
 	tx *sql.Tx
 }
 
 func newTx(t *sql.Tx) *tx {
-	return &tx{s: newSaver(t), f: newFinder(t), tx: t}
-}
-
-func (t *tx) Insert(modelPtr Model) (sql.Result, error) {
-	return t.s.Insert(modelPtr)
-}
-
-func (t *tx) InsertContext(ctx context.Context, modelPtr Model) (sql.Result, error) {
-	return t.s.InsertContext(ctx, modelPtr)
-}
-
-func (t *tx) Update(table string, set map[string]interface{}, where query.Condition) (sql.Result, error) {
-	return t.s.Update(table, set, where)
-}
-
-func (t *tx) UpdateModel(ptr ModelUpdate, where query.Condition) (sql.Result, error) {
-	return t.s.UpdateModel(ptr, where)
-}
-
-func (t *tx) UpdateContext(ctx context.Context, table string, set map[string]interface{}, where query.Condition) (sql.Result, error) {
-	return t.s.UpdateContext(ctx, table, set, where)
-}
-
-func (t *tx) UpdateModelContext(ctx context.Context, ptr ModelUpdate, where query.Condition) (sql.Result, error) {
-	return t.s.UpdateModelContext(ctx, ptr, where)
-}
-
-func (t *tx) Delete(table string, where query.Condition) (sql.Result, error) {
-	return t.s.Delete(table, where)
-}
-
-func (t *tx) DeleteContext(ctx context.Context, table string, where query.Condition) (sql.Result, error) {
-	return t.s.DeleteContext(ctx, table, where)
-}
-
-func (d *tx) Exec(query query.Query) (sql.Result, error) {
-	return d.s.Exec(query)
-}
-
-func (d *tx) ExecContext(ctx context.Context, query query.Query) (sql.Result, error) {
-	return d.s.ExecContext(ctx, query)
-}
-
-func (d *tx) Query(query query.Query) (*sql.Rows, error) {
-	return d.s.Query(query)
-}
-
-func (d *tx) QueryContext(ctx context.Context, query query.Query) (*sql.Rows, error) {
-	return d.s.QueryContext(ctx, query)
-}
-
-func (d *tx) QueryRow(query query.Query) (*sql.Row, error) {
-	return d.s.QueryRow(query)
-}
-
-func (d *tx) QueryRowContext(ctx context.Context, query query.Query) (*sql.Row, error) {
-	return d.s.QueryRowContext(ctx, query)
-}
-
-// Find implements DB
-func (t *tx) Find(q query.Query, destPtrOfStruct any) error {
-	return t.f.Find(q, destPtrOfStruct)
-}
-
-// FindContext implements DB
-func (t *tx) FindContext(ctx context.Context, q query.Query, destPtrOfStruct any) error {
-	return t.f.FindContext(ctx, q, destPtrOfStruct)
-}
-
-// FindMany implements DB
-func (t *tx) FindMany(q query.Query, destSlicePtrOfStruct any) error {
-	return t.f.FindMany(q, destSlicePtrOfStruct)
-}
-
-// FindManyContext implements DB
-func (t *tx) FindManyContext(ctx context.Context, q query.Query, destSlicePtrOfStruct any) error {
-	return t.f.FindManyContext(ctx, q, destSlicePtrOfStruct)
-}
-
-// Deprecated: Use Find or MapRow/MapRows. It will be removed in next version.
-func (t *tx) Map(rows *sql.Rows, destPtr any) error {
-	return MapRow(rows, destPtr)
-}
-
-// Deprecated: Use FindContext or MapRow/MapRows. It will be removed in next version.
-func (t *tx) MapMany(rows *sql.Rows, destSlicePtr any) error {
-	return MapRows(rows, destSlicePtr)
+	return &tx{saver: newSaver(t), finder: newFinder(t), mapper: &mapper{}, tx: t}
 }
 
 func (t *tx) Tx() *sql.Tx {


### PR DESCRIPTION
- added `OpenFunc` params to `exql.OpenOptions`. This acts as the custom opener for `*sql.DB`
- added `exql.OpenContext` func
- changed to use `PingContext(ctx)` instead of `Ping()` 
- removed unnecessary interface implementations in db/tx
- removed deprecation comments for `Mapper` interface