### PR TITLE
fix(security): harden parser and generator against injection

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -53,7 +53,7 @@ func (d *generator) Generate(opts *GenerateOptions) error {
 		opts.Package = "model"
 	}
 	if _, err := os.Stat(opts.OutDir); os.IsNotExist(err) {
-		err := os.Mkdir(opts.OutDir, 0777)
+		err := os.Mkdir(opts.OutDir, 0750)
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func (d *generator) generateModelFile(tableName string, opt *GenerateOptions) er
 	}
 	if fmted, err := format.Source(buf.Bytes()); err != nil {
 		return err
-	} else if err := os.WriteFile(outFile, fmted, os.ModePerm); err != nil {
+	} else if err := os.WriteFile(outFile, fmted, 0640); err != nil {
 		return err
 	}
 	return nil

--- a/generator_test.go
+++ b/generator_test.go
@@ -3,6 +3,7 @@ package exql
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -43,24 +44,67 @@ func TestGenerator_Generate(t *testing.T) {
 				assert.NoError(t, err)
 				checkFiles(dir, []string{"users.go", "user_groups.go", "user_login_histories.go", "group_users.go"})
 			})
-
-			t.Run("should return error when rows.Error() return error", func(t *testing.T) {
-				mockDb, mock, err := sqlmock.New()
+			t.Run("creates output dir with permission 0750", func(t *testing.T) {
+				dir := filepath.Join(t.TempDir(), "output")
+				err := g.Generate(&GenerateOptions{
+					OutDir:  dir,
+					Package: "dist",
+				})
 				assert.NoError(t, err)
-				defer mockDb.Close()
-
-				mock.ExpectQuery(`show tables`).WillReturnRows(
-					sqlmock.NewRows([]string{"tables"}).
-						AddRow("users").
-						RowError(0, fmt.Errorf("err")))
-
+				info, err := os.Stat(dir)
+				assert.NoError(t, err)
+				assert.Equal(t, os.FileMode(0750), info.Mode().Perm())
+			})
+			t.Run("writes files with permission 0640", func(t *testing.T) {
 				dir := t.TempDir()
-				assert.EqualError(t, NewGenerator(mockDb).
-					Generate(&GenerateOptions{
-						OutDir:  dir,
-						Package: "dist",
-					}), "err")
+				err := g.Generate(&GenerateOptions{
+					OutDir:  dir,
+					Package: "dist",
+				})
+				assert.NoError(t, err)
+				entries, err := os.ReadDir(dir)
+				assert.NoError(t, err)
+				for _, e := range entries {
+					info, err := os.Stat(filepath.Join(dir, e.Name()))
+					assert.NoError(t, err)
+					assert.Equal(t, os.FileMode(0640), info.Mode().Perm(), "file: %s", e.Name())
+				}
 			})
 		})
 	}
+
+	t.Run("should return error when rows.Error() return error", func(t *testing.T) {
+		mockDb, mock, err := sqlmock.New()
+		assert.NoError(t, err)
+		defer mockDb.Close()
+
+		mock.ExpectQuery(`show tables`).WillReturnRows(
+			sqlmock.NewRows([]string{"tables"}).
+				AddRow("users").
+				RowError(0, fmt.Errorf("err")))
+
+		dir := t.TempDir()
+		assert.EqualError(t, NewGenerator(mockDb).
+			Generate(&GenerateOptions{
+				OutDir:  dir,
+				Package: "dist",
+			}), "err")
+	})
+
+	t.Run("should propagate ParseTable error", func(t *testing.T) {
+		mockDb, mock, err := sqlmock.New()
+		assert.NoError(t, err)
+		defer mockDb.Close()
+
+		mock.ExpectQuery(`show tables`).WillReturnRows(
+			sqlmock.NewRows([]string{"tables"}).AddRow("users"))
+		mock.ExpectQuery("show columns from `users`").WillReturnError(fmt.Errorf("columns err"))
+
+		dir := t.TempDir()
+		assert.EqualError(t, NewGenerator(mockDb).
+			Generate(&GenerateOptions{
+				OutDir:  dir,
+				Package: "dist",
+			}), "columns err")
+	})
 }

--- a/parser.go
+++ b/parser.go
@@ -115,7 +115,10 @@ func (c *Column) field(goFiledType string) string {
 }
 
 func (p *parser) ParseTable(db *sql.DB, table string) (*Table, error) {
-	rows, err := db.Query(fmt.Sprintf("show columns from %s", table))
+	if strings.ContainsRune(table, '`') {
+		return nil, fmt.Errorf("invalid table name: %q", table)
+	}
+	rows, err := db.Query(fmt.Sprintf("show columns from `%s`", table))
 	if err != nil {
 		return nil, err
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -16,7 +16,7 @@ func TestParser_ParseTable(t *testing.T) {
 
 		p := NewParser()
 
-		mock.ExpectQuery(`show columns from users`).WillReturnRows(
+		mock.ExpectQuery("show columns from `users`").WillReturnRows(
 			sqlmock.NewRows([]string{"field", "type"}).
 				AddRow("id", "int(11)").
 				RowError(0, fmt.Errorf("err")))
@@ -24,6 +24,21 @@ func TestParser_ParseTable(t *testing.T) {
 		table, err := p.ParseTable(mockDb, "users")
 		assert.Nil(t, table)
 		assert.EqualError(t, err, "err")
+	})
+}
+
+func TestParser_ParseTable_SQLInjection(t *testing.T) {
+	t.Run("should return error when table name contains backtick", func(t *testing.T) {
+		mockDb, mock, err := sqlmock.New()
+		assert.NoError(t, err)
+		defer mockDb.Close()
+
+		p := NewParser()
+
+		table, err := p.ParseTable(mockDb, "`users`")
+		assert.Nil(t, table)
+		assert.EqualError(t, err, "invalid table name: \"`users`\"")
+		assert.NoError(t, mock.ExpectationsWereMet())
 	})
 }
 


### PR DESCRIPTION

- parser: reject table names containing backticks with an explicit error instead of embedding the name bare into SQL; quote the name with backticks
- parser_test: update mock expectation to match quoted query; add SQL injection test for backtick-containing table names
- generator: tighten file-system permissions (dir 0777→0750, file 0777→0640)