### PR TITLE
fix(query): preserve grouping for nested conditions

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -111,11 +111,11 @@ func (c *cond) Or(str string, args ...any) {
 }
 
 func (c *cond) AndCond(other Condition) {
-	c.append("AND", other)
+	c.append("AND", groupedQuery{inner: other})
 }
 
 func (c *cond) OrCond(other Condition) {
-	c.append("OR", other)
+	c.append("OR", groupedQuery{inner: other})
 }
 
 func (c *cond) Query() (string, []any, error) {
@@ -131,6 +131,18 @@ func (c *cond) append(sep string, other ...Query) {
 			c.base.append(joiner, v)
 		}
 	}
+}
+
+type groupedQuery struct {
+	inner Query
+}
+
+func (g groupedQuery) Query() (string, []any, error) {
+	stmt, args, err := g.inner.Query()
+	if err != nil {
+		return "", nil, err
+	}
+	return "(" + stmt + ")", args, nil
 }
 
 type chain struct {

--- a/query/query.go
+++ b/query/query.go
@@ -142,6 +142,9 @@ func (g groupedQuery) Query() (string, []any, error) {
 	if err != nil {
 		return "", nil, err
 	}
+	if err := guardQuery(stmt); err != nil {
+		return "", nil, err
+	}
 	return "(" + stmt + ")", args, nil
 }
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -47,10 +47,23 @@ func TestCondition(t *testing.T) {
 		cond.AndCond(q.Cond("foo = ?", "foo"))
 		cond.OrCond(q.Cond("var = ?", "var"))
 		assertQuery(t, cond,
-			"id = ? AND name = ? OR age in (?,?) AND foo = ? OR var = ?",
+			"id = ? AND name = ? OR age in (?,?) AND (foo = ?) OR (var = ?)",
 			1, "go", 20, 21, "foo", "var",
 		)
 	})
+	t.Run("nested conditions are grouped", func(t *testing.T) {
+		tenantScoped := q.Cond("tenant_id = ?", 1)
+		byIDOrEmail := q.Cond("id = ?", 10)
+		byIDOrEmail.Or("email = ?", "user@example.com")
+
+		tenantScoped.AndCond(byIDOrEmail)
+
+		assertQuery(t, tenantScoped,
+			"tenant_id = ? AND (id = ? OR email = ?)",
+			1, 10, "user@example.com",
+		)
+	})
+
 	t.Run("should error if query retuerned an error", func(t *testing.T) {
 		cond := q.CondFrom(q.Q(""))
 		assertQueryErr(t, cond, "DANGER: empty query")

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -6,6 +6,20 @@ import (
 	q "github.com/loilo-inc/exql/v3/query"
 )
 
+type emptyCondition struct{}
+
+func (emptyCondition) Query() (string, []any, error) {
+	return "", nil, nil
+}
+
+func (emptyCondition) And(string, ...any) {}
+
+func (emptyCondition) Or(string, ...any) {}
+
+func (emptyCondition) AndCond(q.Condition) {}
+
+func (emptyCondition) OrCond(q.Condition) {}
+
 func TestQuery(t *testing.T) {
 	assertQuery(t, q.V(1, 2), "?,?", 1, 2)
 	assertQuery(t, q.Vals([]int{1, 2}), "?,?", 1, 2)
@@ -66,6 +80,12 @@ func TestCondition(t *testing.T) {
 
 	t.Run("should error if query retuerned an error", func(t *testing.T) {
 		cond := q.CondFrom(q.Q(""))
+		assertQueryErr(t, cond, "DANGER: empty query")
+	})
+
+	t.Run("should error if grouped condition returned an empty query", func(t *testing.T) {
+		cond := q.Cond("id = ?", 1)
+		cond.AndCond(emptyCondition{})
 		assertQueryErr(t, cond, "DANGER: empty query")
 	})
 }


### PR DESCRIPTION
### Motivation
- Nested Condition composition lost grouping and produced flat predicates like `tenant_id = ? AND id = ? OR email = ?`, altering SQL boolean precedence and potentially broadening authorization-scoped WHERE clauses.

### Description
- Change `AndCond`/`OrCond` to wrap nested `Condition` values in a `groupedQuery` wrapper so the nested SQL is rendered as parenthesized expressions (e.g. `(id = ? OR email = ?)`).
- Add `groupedQuery` type that delegates `Query()` to the inner query and returns the SQL wrapped in parentheses while preserving arguments.
- Keep existing `And`/`Or` string-based behavior unchanged and only alter condition-composition methods that accept `Condition`.
- Update `query/query_test.go` to expect parenthesized nested conditions and add a regression test that asserts `tenant_id = ? AND (id = ? OR email = ?)`.

### Testing
- Ran `go test ./query` which succeeded and covers the updated condition behavior.
- Ran `go test ./...` in this environment which failed due to missing integration DB at `127.0.0.1:13326`, so full test-suite integration tests could not complete here.