### PR TITLE
fix(security): escape generated table-name Go string literal

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -27,15 +27,15 @@ type GenerateOptions struct {
 }
 
 type templateData struct {
-	Imports       string
-	Model         string
-	ModelLower    string
-	M             string
-	Package       string
-	Fields        string
-	UpdaterFields string
-	ScannedFields string
-	TableName     string
+	Imports            string
+	Model              string
+	ModelLower         string
+	M                  string
+	Package            string
+	Fields             string
+	UpdaterFields      string
+	ScannedFields      string
+	TableName          string
 	TableNameGoLiteral string
 }
 
@@ -122,16 +122,16 @@ func (d *generator) generateModelFile(tableName string, opt *GenerateOptions) er
 		}
 	}
 	data := &templateData{
-		Imports:       strings.Join(imports, "\n"),
-		Model:         strcase.ToCamel(table.TableName),
-		ModelLower:    strcase.ToLowerCamel(table.TableName),
-		M:             table.TableName[0:1],
-		UpdaterFields: updateFields.String(),
-		Package:       opt.Package,
-		Fields:        fields.String(),
-		TableName:     tableName,
+		Imports:            strings.Join(imports, "\n"),
+		Model:              strcase.ToCamel(table.TableName),
+		ModelLower:         strcase.ToLowerCamel(table.TableName),
+		M:                  table.TableName[0:1],
+		UpdaterFields:      updateFields.String(),
+		Package:            opt.Package,
+		Fields:             fields.String(),
+		TableName:          tableName,
 		TableNameGoLiteral: strconv.Quote(tableName),
-		ScannedFields: scannedFields.String(),
+		ScannedFields:      scannedFields.String(),
 	}
 	outFile := filepath.Join(
 		opt.OutDir,

--- a/generator.go
+++ b/generator.go
@@ -7,6 +7,7 @@ import (
 	"go/format"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -35,6 +36,7 @@ type templateData struct {
 	UpdaterFields string
 	ScannedFields string
 	TableName     string
+	TableNameGoLiteral string
 }
 
 func NewGenerator(db *sql.DB) Generator {
@@ -128,6 +130,7 @@ func (d *generator) generateModelFile(tableName string, opt *GenerateOptions) er
 		Package:       opt.Package,
 		Fields:        fields.String(),
 		TableName:     tableName,
+		TableNameGoLiteral: strconv.Quote(tableName),
 		ScannedFields: scannedFields.String(),
 	}
 	outFile := filepath.Join(
@@ -167,5 +170,5 @@ func ({{.M}} *Update{{.Model}}) UpdateTableName() string {
 	return {{.Model}}TableName
 }
 
-const {{.Model}}TableName = "{{.TableName}}"
+const {{.Model}}TableName = {{.TableNameGoLiteral}}
 `

--- a/generator_test.go
+++ b/generator_test.go
@@ -2,9 +2,9 @@ package exql
 
 import (
 	"fmt"
-	"regexp"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"

--- a/generator_test.go
+++ b/generator_test.go
@@ -2,6 +2,7 @@ package exql
 
 import (
 	"fmt"
+	"regexp"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,4 +108,31 @@ func TestGenerator_Generate(t *testing.T) {
 				Package: "dist",
 			}), "columns err")
 	})
+}
+
+func TestGenerator_Generate_EscapesTableNameGoLiteral(t *testing.T) {
+	mockDb, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDb.Close()
+
+	table := `x";func init(){panic(1)};var _="`
+	mock.ExpectQuery(`show tables`).WillReturnRows(sqlmock.NewRows([]string{"tables"}).AddRow(table))
+	mock.ExpectQuery(regexp.QuoteMeta(fmt.Sprintf("show columns from `%s`", table))).WillReturnRows(
+		sqlmock.NewRows([]string{"Field", "Type", "Null", "Key", "Default", "Extra"}).
+			AddRow("id", "int(11)", "NO", "PRI", nil, ""),
+	)
+
+	dir := t.TempDir()
+	err = NewGenerator(mockDb).Generate(&GenerateOptions{OutDir: dir, Package: "dist"})
+	assert.NoError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	assert.NoError(t, err)
+	if assert.Len(t, entries, 1) {
+		content, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), `const XfuncInitpanic1varTableName = "x\";func init(){panic(1)};var _=\""`)
+		assert.NotContains(t, string(content), "\nfunc init()")
+	}
+	assert.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
### Motivation

- The generator previously copied raw table names into a Go string literal in the generated source, allowing specially-crafted table names to break out of the string and inject top-level Go code (e.g. an `init` function) during generation and build.
- The parser hardening rejected backticks but allowed other characters that can break Go string literals, so the generator needed to safely escape table names before they reached the template sink.

### Description

- Add `strconv` import and a new `TableNameGoLiteral` field to `templateData` and set it to `strconv.Quote(tableName)` to produce a safe Go string literal for the table name in `generateModelFile` in `generator.go`.
- Update the code generation template to emit the already-escaped literal with `const {{.Model}}TableName = {{.TableNameGoLiteral}}` instead of interpolating raw table names inside quotes.
- Add a regression test `TestGenerator_Generate_EscapesTableNameGoLiteral` in `generator_test.go` that uses `sqlmock` with a malicious table name payload and asserts the generated file contains the escaped literal and does not contain an injected `func init()`.
- Use `regexp.QuoteMeta` in the test to reliably match the `show columns` query containing the payload.

### Testing

- Ran the targeted regression test: `go test ./... -run TestGenerator_Generate_EscapesTableNameGoLiteral -count=1`, which passed.
- The full test suite cannot be fully exercised in this environment because an existing integration test `TestDb_DB` expects a local MySQL instance at `127.0.0.1:13326` and fails with connection refused, so `go test ./...` is not fully reliable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a151d026bdc832ab6f06fdce00efc6f)